### PR TITLE
Set full assets path in constructor

### DIFF
--- a/code/SS_PDF.php
+++ b/code/SS_PDF.php
@@ -8,11 +8,12 @@ class SS_PDF {
 
   private $globalOptions;
   private $pdf;
-  private $folder = ASSETS_PATH . '/';
+  private $folder = ASSETS_PATH;
   private $folderID;
 
   function __construct() {
     $this->setGlobalOptions();
+    $this->folder .= '/';
     $this->pdf = new Pdf($this->globalOptions);
   }
 


### PR DESCRIPTION
PHP error was thrown when appending the trailing slash on the $folder private field.